### PR TITLE
Update compatibility list with new TV model

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,6 +4,7 @@
 
 | TV Model | Year | Jellyfin-web Version | TrueHD Support | SmartHub Support | Notes           |
 | -------- | ---- | -------------------- | -------------- | ---------------- | --------------- |
+| RU710    | 2019 | >= 10.11.z           | unknown        | unknown          | Everything seems to work as expected. The tested model was UE55RU7105KXXC |
 | RU7405   | 2019 | >= 10.8.z            | true           | true             | No known issues |
 | S95C     | 2024 | >= 10.11.z           | true           | false            | SmartHub Preview doesn't seem to work in Tizen 9 |
 


### PR DESCRIPTION
Update the compatibility list with the Samsung TV model "RU710".

Sorry for creating a new pull request and a new issue. I realized that in the first pull request the row wasn't in alphabetical order, which might be a good idea for easier consultation in the future.